### PR TITLE
make [] read as a vector

### DIFF
--- a/clojure/lang/reader.rkt
+++ b/clojure/lang/reader.rkt
@@ -4,13 +4,25 @@ clojure/clojure
 (lambda (t)
   (parameterize ([current-readtable (make-clojure-readtable)])
     (t)))
+
 (define (make-clojure-readtable [rt (current-readtable)])
   (make-readtable rt
                   #\~ #\, #f
                   #\, #\space #f
                   #\_ 'dispatch-macro s-exp-comment-proc
+                  #\[ 'terminating-macro vec-proc
                   ))
 
 (define (s-exp-comment-proc ch in src ln col pos)
   (make-special-comment (read-syntax/recursive src in)))
+
+(define (vec-proc ch in src ln col pos)
+  (define lst-stx
+    (parameterize ([read-accept-dot #f])
+      (read-syntax/recursive src in ch (make-readtable (current-readtable) ch #\[ #f))))
+  (define lst (syntax->list lst-stx))
+  (datum->syntax lst-stx (list->immutable-vector lst) lst-stx lst-stx))
+
+(define (list->immutable-vector lst)
+  (apply vector-immutable lst))
 

--- a/clojure/tests/test.rkt
+++ b/clojure/tests/test.rkt
@@ -5,9 +5,14 @@
 (displayln [1 2 3])
 (check-true (vector? [1 2 3]))
 (check-true (vector? '[1 2 3]))
+(check-true (immutable? [1 2 3]))
+(check-true (immutable? '[1 2 3]))
 (displayln {:a 5 :b 7})
 (displayln {:a 5, :b 7})
 (check-equal? [1,2,3] [1 2 3])
+(check-equal? [1 2 (+ 1 2)] [1 2 3])
+(check-equal? '[1 2 (+ 1 2)] [1 2 '(+ 1 2)])
+(check-equal? [1 2 [3]] (vector-immutable 1 2 (vector-immutable 3)))
 
 (def foo 3)
 foo


### PR DESCRIPTION
and make sure [(+ 1 2)] evaluates equal to (vector-immutable 3), and
clean up no-longer-necessary handling of [ ‘paren-shape and unquote in
#%app, quote, let, etc.

fixes https://github.com/takikawa/racket-clojure/issues/1