### PR TITLE
define nil as (void) instead of #f

### DIFF
--- a/clojure/clojure.rkt
+++ b/clojure/clojure.rkt
@@ -3,6 +3,7 @@
 ;; Clojure compatibility
 
 (require racket/stxparam
+         "nil.rkt"
          (for-syntax racket/base
                      racket/list
                      syntax/parse))
@@ -36,8 +37,6 @@
 
 (define true #t)
 (define false #f)
-;;nil maps most closely to #f
-(define nil #f)
 
 ;; used for let and loop
 (begin-for-syntax
@@ -105,12 +104,15 @@
     [(_ x form form_1 ...)
      #'(->> (->> x form) form_1 ...)]))
 
+(define (true? v)
+  (not (or (eq? v #f) (eq? v nil))))
+
 (define-syntax (clojure:if stx)
   (syntax-parse stx
     [(_ test then) 
-     #'(if test then #f)]
+     #'(if (true? test) then nil)]
     [(_ test then else) 
-     #'(if test then else)]))
+     #'(if (true? test) then else)]))
 
 ;; modify lexical syntax via macros
 (begin-for-syntax
@@ -167,7 +169,7 @@
        #'else-expr]
       [(_ e1 e2 e3 ...)
        (if (even? (length (syntax->list #'(e1 e2 e3 ...))))
-           #'(if e1 e2
+           #'(if (true? e1) e2
                  (clojure:cond e3 ...))
            (raise-syntax-error #f "cond requires an even number of forms" stx))])))
 

--- a/clojure/nil.rkt
+++ b/clojure/nil.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(provide nil nil?)
+
+(define nil (void))
+
+(define (nil? v) (void? v))
+

--- a/clojure/tests/test.rkt
+++ b/clojure/tests/test.rkt
@@ -33,7 +33,7 @@ foo
   (+ x y))
 
 ;; TODO: make `nil` reader syntax
-(check-equal? (if #f 5) #f)
+(check-equal? (if #f 5) nil)
 
 (check-equal?
  (loop [x 5 n 1]


### PR DESCRIPTION
It seems to me like `nil` maps most closely to `#<void>`, but with `if` handling it differently. Or are there more reasons why `nil` should be `#f` other than that?

By the way, the motivation is that I'm thinking of implementing the clojure printer, which would have to distinguish them.  That's also why I put `nil` in a separate file, so that the printer could be in it's own file and depend on `nil.rkt`.  The motivation for implementing the clojure printer is that if I want to add anonymous function literals like `#(+ % 1)` as `(fn [%] (+ % 1))` then that would be confusing if the vector `['+ '% 1]` prints like that.  

But this pull request is just about `nil`.